### PR TITLE
T-165 fix: reset quiz state on navigation to summary screen

### DIFF
--- a/apps/mobile/app/(tabs)/daily-quiz.tsx
+++ b/apps/mobile/app/(tabs)/daily-quiz.tsx
@@ -731,6 +731,7 @@ export default function DailyQuizScreen() {
                       iconName="document-text-outline"
                       onPress={() => {
                         router.push({ pathname: '/(tabs)/summary', params: { gameId: gameInstanceId!.toString() } });
+                        setQuizState(null);
                       }}
                     />
                   ) : (


### PR DESCRIPTION
- Added logic to set quiz state to null when navigating to the summary screen from the daily quiz. This ensures that the quiz state is properly reset, preventing potential issues with stale data.