### PR TITLE
fix(mobile): declare expo-image-picker/-manipulator deps to fix Profile crash on native builds

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -47,7 +47,14 @@
         }
       ],
       "expo-font",
-      "expo-web-browser"
+      "expo-web-browser",
+      [
+        "expo-image-picker",
+        {
+          "photosPermission": "Cashou utilise vos photos pour définir votre avatar de profil.",
+          "cameraPermission": "Cashou utilise l'appareil photo pour prendre une photo de profil."
+        }
+      ]
     ],
     "experiments": {
       "typedRoutes": true,

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -35,6 +35,8 @@
         "expo-font": "~14.0.11",
         "expo-haptics": "~15.0.8",
         "expo-image": "~3.0.11",
+        "expo-image-manipulator": "~14.0.8",
+        "expo-image-picker": "~17.0.10",
         "expo-linear-gradient": "~15.0.8",
         "expo-linking": "~8.0.11",
         "expo-notifications": "~0.32.16",

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cashou",
@@ -127,6 +128,8 @@
         "expo-font": "~14.0.11",
         "expo-haptics": "~15.0.8",
         "expo-image": "~3.0.11",
+        "expo-image-manipulator": "~14.0.8",
+        "expo-image-picker": "~17.0.10",
         "expo-linear-gradient": "~15.0.8",
         "expo-linking": "~8.0.11",
         "expo-notifications": "~0.32.16",


### PR DESCRIPTION
## Problème
En build natif (TestFlight), l'app **crash au clic sur l'onglet Profil**, alors que tout fonctionne en dev Expo.

## Cause racine
`components/profile/EditProfileModal.tsx` (monté systématiquement via `<UserProfile/>`) importe au niveau module `expo-image-picker` et `expo-image-manipulator`, qui font un `requireNativeModule(...)` au chargement.

Ces deux packages n'étaient **pas déclarés dans `apps/mobile/package.json`** (seulement au `package.json` racine → hoistés). Metro les résout en dev, mais l'autolinking natif ne lie que les deps déclarées dans le `package.json` de l'app → modules absents du binaire release → `requireNativeModule` échoue → crash.

## Correctif
- `apps/mobile/package.json` : déclaration de `expo-image-manipulator ~14.0.8` et `expo-image-picker ~17.0.10` (versions alignées SDK 54, déjà figées dans le lockfile).
- `apps/mobile/app.json` : ajout du plugin `expo-image-picker` avec les 2 permissions iOS (photos + caméra).
- `bun.lock` : mis à jour, `bun install --frozen-lockfile` passe (no changes).

## Vérifs
- Audit complet des imports `apps/mobile` : 35 packages importés, 0 dépendance fantôme restante.
- `bun install --frozen-lockfile` OK localement (ce que fait la CI).

## ⚠️ Nécessite un REBUILD natif iOS
Ce correctif ajoute du code natif → un update JS/OTA ne suffit pas. Après merge : `eas build` (prod) ou `expo prebuild` + `pod install`, puis nouvel upload TestFlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)